### PR TITLE
chore(deps): no canvas

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -20,8 +20,5 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^8.0.0"
-  },
-  "optionalDependencies": {
-    "canvas": "^2.0.0"
   }
 }


### PR DESCRIPTION
For some weird reason, the samples here depend on `canvas` as an optional dependency. There is no reason for them to do so. Canvas is a binary native dependency using `node-gyp` that breaks stuff :)  Removing it.

(in case if `canvas` is needed for any of the libraries, `pureimage` is a good replacement, as shown in this Vision PR: https://github.com/googleapis/nodejs-vision/pull/774)